### PR TITLE
Set PS1 after .bashrc

### DIFF
--- a/sshh/main.py
+++ b/sshh/main.py
@@ -110,7 +110,8 @@ def cmd_agent(request):
         sshenv['PS1'] = f"[{request.group}]{sshenv['PS1']}"
         logger.info('ssh-agent PID=%s session "%s" has been started. To close this session, exit shell.',
                     sshenv['SSH_AGENT_PID'], request.group)
-        subprocess.run (sshenv['SHELL'], env=sshenv)
+        bash_command = f'{sshenv["SHELL"]} --init-file <(echo "export PS1={sshenv["PS1"]}"'
+        subprocess.run(bash_command, env=sshenv)
     finally:
         # kill agent
         subprocess.run(['ssh-agent', '-k'], env=sshenv, stdout=subprocess.DEVNULL)

--- a/sshh/main.py
+++ b/sshh/main.py
@@ -110,7 +110,7 @@ def cmd_agent(request):
         sshenv['PS1'] = f"[{request.group}]{sshenv['PS1']}"
         logger.info('ssh-agent PID=%s session "%s" has been started. To close this session, exit shell.',
                     sshenv['SSH_AGENT_PID'], request.group)
-        bash_command = f'{sshenv["SHELL"]} --init-file <(echo "export PS1={sshenv["PS1"]}"'
+        bash_command = f'{sshenv["SHELL"]} --rcfile <(echo ". $HOME/.bashrc; PS1=hogefuga: {sshenv["PS1"]}"'
         subprocess.run(bash_command, env=sshenv)
     finally:
         # kill agent

--- a/sshh/main.py
+++ b/sshh/main.py
@@ -110,8 +110,11 @@ def cmd_agent(request):
         sshenv['PS1'] = f"[{request.group}]{sshenv['PS1']}"
         logger.info('ssh-agent PID=%s session "%s" has been started. To close this session, exit shell.',
                     sshenv['SSH_AGENT_PID'], request.group)
-        bash_command = f'{sshenv["SHELL"]} --rcfile <(echo ". $HOME/.bashrc; PS1={sshenv["PS1"]}"'
-        subprocess.run(bash_command, env=sshenv)
+        shell_command = sshenv['SHELL']
+        if Path(bash_command).name.lower() == 'bash':
+            # set PS1 after bash execution if shell program is bash
+            shell_command = f'{shell_command} --rcfile <(echo ". $HOME/.bashrc; PS1={sshenv["PS1"]}"'
+        subprocess.run(shell_command, env=sshenv)
     finally:
         # kill agent
         subprocess.run(['ssh-agent', '-k'], env=sshenv, stdout=subprocess.DEVNULL)

--- a/sshh/main.py
+++ b/sshh/main.py
@@ -110,7 +110,7 @@ def cmd_agent(request):
         sshenv['PS1'] = f"[{request.group}]{sshenv['PS1']}"
         logger.info('ssh-agent PID=%s session "%s" has been started. To close this session, exit shell.',
                     sshenv['SSH_AGENT_PID'], request.group)
-        bash_command = f'{sshenv["SHELL"]} --rcfile <(echo ". $HOME/.bashrc; PS1=hogefuga: {sshenv["PS1"]}"'
+        bash_command = f'{sshenv["SHELL"]} --rcfile <(echo ". $HOME/.bashrc; PS1={sshenv["PS1"]}"'
         subprocess.run(bash_command, env=sshenv)
     finally:
         # kill agent


### PR DESCRIPTION
Uses `--rcfile` to override PS1 _after_ loading shell instance (overrides `.bashrc` PS1 settings)